### PR TITLE
Fix modal scroll issue and replace for-loop with forEach for cleaner …

### DIFF
--- a/script.js
+++ b/script.js
@@ -8,7 +8,8 @@ const overlay = document.querySelector('.overlay');
 const btnCloseModal = document.querySelector('.btn--close-modal');
 const btnsOpenModal = document.querySelectorAll('.btn--show-modal');
 
-const openModal = function () {
+const openModal = function (e) {
+  e.preventDefault();
   modal.classList.remove('hidden');
   overlay.classList.remove('hidden');
 };
@@ -18,8 +19,7 @@ const closeModal = function () {
   overlay.classList.add('hidden');
 };
 
-for (let i = 0; i < btnsOpenModal.length; i++)
-  btnsOpenModal[i].addEventListener('click', openModal);
+btnsOpenModal.forEach(btn => btn.addEventListener('click', openModal));
 
 btnCloseModal.addEventListener('click', closeModal);
 overlay.addEventListener('click', closeModal);


### PR DESCRIPTION
##  Fix Modal Trigger Behavior and Modernize Loop

### Changes
- Added `e.preventDefault();` to prevent default anchor scroll when opening modal.
- Replaced old `for` loop with modern `forEach()` method for cleaner code.

### Before
```js
for (let i = 0; i < btnsOpenModal.length; i++)
  btnsOpenModal[i].addEventListener('click', openModal);
