### PR TITLE
Implement menu fade animation with event handler arguments using bind()

### DIFF
--- a/script.js
+++ b/script.js
@@ -6,6 +6,11 @@ const btnCloseModal = document.querySelector('.btn--close-modal');
 const btnsOpenModal = document.querySelectorAll('.btn--show-modal');
 const btnScrollTo = document.querySelector('.btn--scroll-to');
 const section1 = document.querySelector('#section--1');
+const nav = document.querySelector('.nav');
+// Tabbed components
+const tabs = document.querySelectorAll('.operations__tab');
+const tabsContainer = document.querySelector('.operations__tab-container');
+const tabsContent = document.querySelectorAll('.operations__content');
 
 ///////////////////////////////////////
 // Modal window
@@ -86,11 +91,6 @@ document.querySelector('.nav__links').addEventListener('click', function (e) {
   }
 });
 
-// Tabbed components
-const tabs = document.querySelectorAll('.operations__tab');
-const tabsContainer = document.querySelector('.operations__tab-container');
-const tabsContent = document.querySelectorAll('.operations__content');
-
 tabsContainer.addEventListener('click', function (e) {
   const clicked = e.target.closest('.operations__tab');
 
@@ -109,6 +109,27 @@ tabsContainer.addEventListener('click', function (e) {
     .querySelector(`.operations__content--${clicked.dataset.tab}`)
     .classList.add('operations__content--active');
 });
+
+// menu fade animation
+const handleHover = function (e, opacity) {
+  console.log(this, e.currentTarget);
+  if (e.target.classList.contains('nav__link')) {
+    const link = e.target;
+    const siblings = link.closest('.nav').querySelectorAll('.nav__link');
+    console.log(siblings);
+    const logo = link.closest('.nav').querySelector('img');
+
+    siblings.forEach(el => {
+      if (el !== link) el.style.opacity = this;
+    });
+
+    logo.style.opacity = this;
+  }
+};
+
+// Passing "argument" into handler
+nav.addEventListener('mouseover', handleHover.bind(0.5));
+nav.addEventListener('mouseout', handleHover.bind(1));
 
 //////////////////////////////////////////
 //////////////////////////////////////////


### PR DESCRIPTION
## 📌 Summary

This PR implements a hover effect on the navigation links, where hovering on one link fades out the other links and the logo. This is done using event delegation and passing an argument (opacity) into the event handler using `.bind()`.

## ✅ What’s included
- `mouseover` and `mouseout` event handlers bound to the `.nav` element
- `handleHover` function that adjusts opacity of sibling links and logo
- Efficient use of `.bind()` to simulate argument passing into the handler

## 📖 Learning Point
This section demonstrates how to pass values (like opacity) into event listeners by binding `this`, since native event handlers only accept one parameter (the event).

```js
nav.addEventListener('mouseover', handleHover.bind(0.5));
nav.addEventListener('mouseout', handleHover.bind(1));
