### PR TITLE
Fix initial page load bug in reveal-on-scroll logic

### DIFF
--- a/script.js
+++ b/script.js
@@ -176,12 +176,12 @@ headerObserver.observe(header);
 const allSections = document.querySelectorAll('section');
 
 const revelSection = function (entries, observer) {
-  const [entry] = entries;
-  console.log(entry);
-
-  if (!entry.isIntersecting) return;
-  entry.target.classList.remove('section--hidden');
-  observer.unobserve(entry.target);
+  // console.log(entries);
+  entries.forEach(entry => {
+    if (!entry.isIntersecting) return;
+    entry.target.classList.remove('section--hidden');
+    observer.unobserve(entry.target);
+  });
 };
 
 const sectionObserver = new IntersectionObserver(revelSection, {


### PR DESCRIPTION
## 🐞 Bug Fix: Reveal-on-Scroll Fails on Reload Midway

This PR fixes a bug where some sections would remain hidden if the page is reloaded while the user is between sections.

## ✅ What Was Happening?

- When reloading mid-scroll, the `IntersectionObserver` would observe all sections.
- But the previous implementation only handled the **first intersecting entry**, missing the others already in view.

## 🛠 Fix

- Updated the `revealSection` function to loop through **all** `entries` using `forEach`.
- Now it checks every observed element on load and removes the hidden class if it's intersecting.

## 🔄 Updated Function

```js
const revelSection = function (entries, observer) {
  entries.forEach(entry => {
    if (!entry.isIntersecting) return;
    entry.target.classList.remove('section--hidden');
    observer.unobserve(entry.target);
  });
};
